### PR TITLE
feat(): Add option to block S3 public access to origin bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,17 @@ resource "aws_s3_bucket" "origin" {
   }
 }
 
+# Block public access for origin S3 bucket
+resource "aws_s3_bucket_public_access_block" "backups" {
+  count  = signum(length(var.origin_bucket)) == 1 && var.block_public_access ? 0 : 1
+  bucket = aws_s3_bucket.origin[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}
+
 module "distribution_label" {
   source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.8.0"
   namespace  = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_s3_bucket" "origin" {
 
 # Block public access for origin S3 bucket
 resource "aws_s3_bucket_public_access_block" "backups" {
-  count  = signum(length(var.origin_bucket)) == 1 && var.block_public_access ? 0 : 1
+  count  = signum(length(var.origin_bucket)) == 1 && !var.block_public_access ? 0 : 1
   bucket = aws_s3_bucket.origin[0].id
 
   block_public_acls       = true

--- a/variables.tf
+++ b/variables.tf
@@ -279,3 +279,9 @@ variable "custom_error_response" {
   description = "List of one or more custom error response element maps"
   default     = []
 }
+
+variable "block_public_access" {
+  description = "Block public access to origin S3 bucket if true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
As the title says. Add `block_public_access` tfvar variable to conditionally deploy `aws_s3_bucket_public_access_block` resource to block S3 public access to the origin bucket.