### PR TITLE
fix(): Allow option to not create DNS entries for CDN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
+  count            = var.create_dns_entry ? 1 : 0
   source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.8.2"
   enabled          = var.enabled
   aliases          = var.aliases

--- a/variables.tf
+++ b/variables.tf
@@ -285,3 +285,9 @@ variable "block_public_access" {
   type        = bool
   default     = true
 }
+
+variable "create_dns_entry" {
+  description = "Create a DNS entry in Route 53 based on the domain(s) provided"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Jira: [Allow option not to create DNS entries for CDN](https://rewind.atlassian.net/browse/DEVOPS-2372)

## Description of Change
This change provides the option in the module not to create the DNS entries for the CloudFront domain. This is useful in the case that the domain already exists and is managed elsewhere.

The use case in question is where the app.rewind.com domain is managed separately and we would like to stand up a static site fronted by a CloudFront distribution for the app in the event it goes down (regional failure) and we want a secondary failover point for the domain entry.