### PR TITLE
fix(): Update typo in principal key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "origin" {
     resources = ["arn:aws:s3:::${local.bucket}${coalesce(var.origin_path, "/")}*"]
 
     principals {
-      type        = "service"
+      type        = "Service"
       identifiers = ["cloudfront.amazonaws.com"]
     }
 
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "origin" {
     resources = ["arn:aws:s3:::${local.bucket}"]
 
     principals {
-      type        = "service"
+      type        = "Service"
       identifiers = ["cloudfront.amazonaws.com"]
     }
 


### PR DESCRIPTION
Service needs to be capitalized, otherwise Terraform barfs on the policy syntax being invalid on apply. This is NOT caught during the plan stages.