### PR TITLE
fix(): Don't remove OAI until switched over

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,10 @@ module "origin_label" {
   tags       = var.tags
 }
 
+resource "aws_cloudfront_origin_access_identity" "default" {
+  comment = module.distribution_label.id
+}
+
 resource "aws_cloudfront_origin_access_control" "default" {
   name                              = "cf-s3-oac"
   origin_access_control_origin_type = "s3"


### PR DESCRIPTION
## Description of Change
Preserve the OAI resource until everything is moved over. Removing while switching over fails the Terraform apply step.