### PR TITLE
fix(): Use distro ARN for conditional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,9 +31,9 @@ data "aws_iam_policy_document" "origin" {
 
     condition {
       test = "StringLike"
-      variable = "aws:sourceArn"
+      variable = "aws:SourceArn"
 
-      values = [module.distribution_label.id]
+      values = [aws_cloudfront_distribution.default.arn]
     }
   }
 
@@ -48,9 +48,9 @@ data "aws_iam_policy_document" "origin" {
 
     condition {
       test = "StringLike"
-      variable = "aws:sourceArn"
+      variable = "aws:SourceArn"
 
-      values = [module.distribution_label.id]
+      values = [aws_cloudfront_distribution.default.arn]
     }
   }
 }


### PR DESCRIPTION
## Description of Change
The conditional statement in the policy requires an ARN, an ID is not sufficient and it needs to source the distribution itself, not the origin.

These are slight changes from the OAI method of access.

## Testing Performed
Switched the staging environment over to OAC and ran a curl on the distro to get an "Access Denied". Then changed the bucket policy to align with this format and retried to confirm I could access the feature flag file.