### PR TITLE
fix(): Remove legacy OAI origin completely from module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,6 @@ module "origin_label" {
   tags       = var.tags
 }
 
-resource "aws_cloudfront_origin_access_identity" "default" {
-  comment = module.distribution_label.id
-}
-
 resource "aws_cloudfront_origin_access_control" "default" {
   name                              = "cf-s3-oac"
   origin_access_control_origin_type = "s3"


### PR DESCRIPTION
## Description of Change
This change removes the Origin Access Identity from the configuration completely now that we've moved our staging and production environments over to the Origin Access Control method.