### PR TITLE
fix(): Use unique names for OACs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "origin_label" {
 }
 
 resource "aws_cloudfront_origin_access_control" "default" {
-  name                              = "cf-s3-oac"
+  name                              = "${var.name}-cf-s3-oac"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
   signing_protocol                  = "sigv4"


### PR DESCRIPTION
## Description of Change
OAC names need to be unique between regions in the same account.