### PR TITLE
fix(): Add Trivy ignores

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,7 @@ locals {
   bucket_domain_name = var.use_regional_s3_endpoint == "true" ? format("%s.s3-%s.amazonaws.com", local.bucket, data.aws_s3_bucket.selected.region) : format(var.bucket_domain_format, local.bucket)
 }
 
+#trivy:ignore:AVD-AWS-0011 Distribution does not have WAF enabled by default
 resource "aws_cloudfront_distribution" "default" {
   enabled             = var.enabled
   is_ipv6_enabled     = var.is_ipv6_enabled


### PR DESCRIPTION
# Jira: [Add Trivy ignores](https://rewind.atlassian.net/browse/DEVOPS-2669)

## Description of Change
This change adds an ignore for Trivy rules around the CF distros having WAFs by default.